### PR TITLE
add .git/ to .gitingore in result of an 'bug'/error caused by npm;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,6 @@ __pycache__/
 # should be stored in the .pubxml.user file.
 
 # End of https://www.gitignore.io/api/sublimetext,visualstudio,webstorm+all,visualstudiocode
+
+# Git
+.git/


### PR DESCRIPTION
When you install dts-bundle-webpack (npm i -D ...) and tries to install any other package or runs a simple npm update, then npm will complain, that the git repository in ./node_modules/dts-bundle-webpack/ is not clean and should be committed first. 

When you look in ./node_modules/dts-bundle-webpack/, you will see that there is a .git/ folder.

So you are forced to remove the ./node_modules/dts-bundle-webpack/.git folder or the entire ./node_modules/dts-bundle-webpack/ folder before you can update your packages or install a new package.

This simple pull request adds .git/ to .gitignore.